### PR TITLE
DT-9731: [DT-10524] support native datafied volume creation

### DIFF
--- a/internal/datafy/client.go
+++ b/internal/datafy/client.go
@@ -7,8 +7,6 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/hashicorp/terraform-provider-aws/version"
 )
 
@@ -57,10 +55,6 @@ type createDatafiedVolumeProperties struct {
 
 type createDatafiedVolumeRequest struct {
 	VolumeProperties createDatafiedVolumeProperties `json:"volumeProperties"`
-}
-
-type createDatafiedVolumeResponse struct {
-	VolumeId string `json:"volumeId"`
 }
 
 type attachVolumeRequest struct {
@@ -207,15 +201,11 @@ func (c *ClientImpl) CreateDatafiedVolume(availabilityZone string, diskSize int6
 	defer drain(resp)
 
 	if resp.StatusCode == http.StatusOK {
-		var out createDatafiedVolumeResponse
+		var out Volume
 		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 			return nil, err
 		}
-		return &Volume{
-			Volume:     &types.Volume{VolumeId: aws.String(out.VolumeId)},
-			IsManaged:  true,
-			IsDatafied: true,
-		}, nil
+		return &out, nil
 	}
 
 	return nil, toError(resp)

--- a/internal/datafy/client.go
+++ b/internal/datafy/client.go
@@ -15,6 +15,7 @@ const DefaultUrl = "https://iac.datafy.io"
 type Client interface {
 	GetVolume(volumeId string) (*Volume, error)
 	CreateVolumeFromSnapshot(datafySnapshotId string, availabilityZone string, iops int32, throughput int32, tagz map[string]string) (*RestoredVolume, error)
+	CreateDatafiedVolume(availabilityZone string, diskSize int64, iops *int32, throughput *int32, encrypted *bool, kmsKeyId string, tagz map[string]string) (*DatafiedVolume, error)
 	AttachVolume(instanceId string, volumeId string, deviceName string) error
 	DetachVolume(instanceId string, volumeId string) error
 	ModifyVolume(volumeId string, sizeGb *int32, iops *int32, throughput *int32) error
@@ -40,6 +41,28 @@ type createFromSnapshotsVolumeProperties struct {
 type createFromSnapshotsRequest struct {
 	Source           createFromSnapshotsSource           `json:"source"`
 	VolumeProperties createFromSnapshotsVolumeProperties `json:"volumeProperties"`
+}
+
+type createDatafiedVolumeProperties struct {
+	AvailabilityZone string `json:"availabilityZone"`
+	DiskSize         int64  `json:"diskSize"`
+	VolumeIops       *int32 `json:"volumeIops,omitempty"`
+	VolumeThroughput *int32 `json:"volumeThroughput,omitempty"`
+	Encrypted        *bool  `json:"encrypted,omitempty"`
+	KmsKeyId         string `json:"kmsKeyId,omitempty"`
+	Tags             []tags `json:"tags,omitempty"`
+}
+
+type createDatafiedVolumeRequest struct {
+	VolumeProperties createDatafiedVolumeProperties `json:"volumeProperties"`
+}
+
+type createDatafiedVolumeResponse struct {
+	VolumeId         string   `json:"volumeId"`
+	TargetVolumeIds  []string `json:"targetVolumeIds"`
+	VolumeProperties struct {
+		DiskSize int64 `json:"diskSize"`
+	} `json:"volumeProperties"`
 }
 
 type attachVolumeRequest struct {
@@ -157,6 +180,44 @@ func (c *ClientImpl) CreateVolumeFromSnapshot(datafySnapshotId string, availabil
 			return nil, err
 		}
 		return &out, nil
+	}
+
+	return nil, toError(resp)
+}
+
+func (c *ClientImpl) CreateDatafiedVolume(availabilityZone string, diskSize int64, iops *int32, throughput *int32, encrypted *bool, kmsKeyId string, tagz map[string]string) (*DatafiedVolume, error) {
+	tagsList := make([]tags, 0, len(tagz))
+	for k, v := range tagz {
+		tagsList = append(tagsList, tags{Key: k, Value: v})
+	}
+	request := createDatafiedVolumeRequest{
+		VolumeProperties: createDatafiedVolumeProperties{
+			AvailabilityZone: availabilityZone,
+			DiskSize:         diskSize,
+			VolumeIops:       iops,
+			VolumeThroughput: throughput,
+			Encrypted:        encrypted,
+			KmsKeyId:         kmsKeyId,
+			Tags:             tagsList,
+		},
+	}
+
+	resp, err := c.sendRequest(http.MethodPost, "api/v1/aws/volumes/create-datafied-volume", request)
+	if err != nil {
+		return nil, err
+	}
+	defer drain(resp)
+
+	if resp.StatusCode == http.StatusOK {
+		var out createDatafiedVolumeResponse
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			return nil, err
+		}
+		return &DatafiedVolume{
+			VolumeId:        out.VolumeId,
+			TargetVolumeIds: out.TargetVolumeIds,
+			DiskSize:        out.VolumeProperties.DiskSize,
+		}, nil
 	}
 
 	return nil, toError(resp)

--- a/internal/datafy/client.go
+++ b/internal/datafy/client.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/hashicorp/terraform-provider-aws/version"
 )
 
@@ -15,7 +17,7 @@ const DefaultUrl = "https://iac.datafy.io"
 type Client interface {
 	GetVolume(volumeId string) (*Volume, error)
 	CreateVolumeFromSnapshot(datafySnapshotId string, availabilityZone string, iops int32, throughput int32, tagz map[string]string) (*RestoredVolume, error)
-	CreateDatafiedVolume(availabilityZone string, diskSize int64, iops *int32, throughput *int32, encrypted *bool, kmsKeyId string, tagz map[string]string) (*DatafiedVolume, error)
+	CreateDatafiedVolume(availabilityZone string, diskSize int64, iops *int32, throughput *int32, encrypted *bool, kmsKeyId string, tagz map[string]string) (*Volume, error)
 	AttachVolume(instanceId string, volumeId string, deviceName string) error
 	DetachVolume(instanceId string, volumeId string) error
 	ModifyVolume(volumeId string, sizeGb *int32, iops *int32, throughput *int32) error
@@ -58,11 +60,7 @@ type createDatafiedVolumeRequest struct {
 }
 
 type createDatafiedVolumeResponse struct {
-	VolumeId         string   `json:"volumeId"`
-	TargetVolumeIds  []string `json:"targetVolumeIds"`
-	VolumeProperties struct {
-		DiskSize int64 `json:"diskSize"`
-	} `json:"volumeProperties"`
+	VolumeId string `json:"volumeId"`
 }
 
 type attachVolumeRequest struct {
@@ -185,7 +183,7 @@ func (c *ClientImpl) CreateVolumeFromSnapshot(datafySnapshotId string, availabil
 	return nil, toError(resp)
 }
 
-func (c *ClientImpl) CreateDatafiedVolume(availabilityZone string, diskSize int64, iops *int32, throughput *int32, encrypted *bool, kmsKeyId string, tagz map[string]string) (*DatafiedVolume, error) {
+func (c *ClientImpl) CreateDatafiedVolume(availabilityZone string, diskSize int64, iops *int32, throughput *int32, encrypted *bool, kmsKeyId string, tagz map[string]string) (*Volume, error) {
 	tagsList := make([]tags, 0, len(tagz))
 	for k, v := range tagz {
 		tagsList = append(tagsList, tags{Key: k, Value: v})
@@ -213,10 +211,10 @@ func (c *ClientImpl) CreateDatafiedVolume(availabilityZone string, diskSize int6
 		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 			return nil, err
 		}
-		return &DatafiedVolume{
-			VolumeId:        out.VolumeId,
-			TargetVolumeIds: out.TargetVolumeIds,
-			DiskSize:        out.VolumeProperties.DiskSize,
+		return &Volume{
+			Volume:     &types.Volume{VolumeId: aws.String(out.VolumeId)},
+			IsManaged:  true,
+			IsDatafied: true,
 		}, nil
 	}
 

--- a/internal/datafy/client.go
+++ b/internal/datafy/client.go
@@ -194,7 +194,7 @@ func (c *ClientImpl) CreateDatafiedVolume(availabilityZone string, diskSize int6
 		},
 	}
 
-	resp, err := c.sendRequest(http.MethodPost, "api/v1/aws/volumes/create-datafied-volume", request)
+	resp, err := c.sendRequest(http.MethodPost, "api/v1/aws/volumes/create-autoscaling-volume", request)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/datafy/mock_client.go
+++ b/internal/datafy/mock_client.go
@@ -106,6 +106,52 @@ func (m *MockClient) CreateVolumeFromSnapshot(datafySnapshotId string, availabil
 	return restoredVolume, nil
 }
 
+func (m *MockClient) CreateDatafiedVolume(availabilityZone string, diskSize int64, iops *int32, throughput *int32, _ *bool, _ string, tagz map[string]string) (*DatafiedVolume, error) {
+	sourceVolumeId := fmt.Sprintf("vol-%016x", time.Now().UnixNano())
+
+	tags := []types.Tag{
+		{Key: aws.String(managedByTagKey), Value: aws.String(managedByTagValue)},
+		{Key: aws.String(sourceVolumeTagKey), Value: aws.String(sourceVolumeId)},
+		{Key: aws.String(VolumeSourceTagKey), Value: aws.String(VolumeSourceNative)},
+	}
+	for key, value := range tagz {
+		tags = append(tags, types.Tag{Key: aws.String(key), Value: aws.String(value)})
+	}
+
+	var targetIds []string
+	for range 2 {
+		out, err := m.ec2Client.CreateVolume(context.Background(), &ec2.CreateVolumeInput{
+			AvailabilityZone: aws.String(availabilityZone),
+			Size:             aws.Int32(int32(diskSize)),
+			VolumeType:       types.VolumeTypeGp3,
+			Iops:             iops,
+			Throughput:       throughput,
+			TagSpecifications: []types.TagSpecification{
+				{ResourceType: types.ResourceTypeVolume, Tags: tags},
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		targetIds = append(targetIds, aws.ToString(out.VolumeId))
+	}
+
+	m.SetVolume(sourceVolumeId, &Volume{
+		Volume: &types.Volume{
+			VolumeId:         aws.String(sourceVolumeId),
+			AvailabilityZone: aws.String(availabilityZone),
+			Size:             aws.Int32(int32(diskSize)),
+			Iops:             iops,
+			Throughput:       throughput,
+		},
+		IsManaged:  true,
+		IsDatafied: true,
+		HasSource:  false,
+	})
+
+	return &DatafiedVolume{VolumeId: sourceVolumeId, TargetVolumeIds: targetIds, DiskSize: diskSize}, nil
+}
+
 func (m *MockClient) AttachVolume(instanceId string, volumeId string, _ string) error {
 	dvo, err := m.ec2Client.DescribeVolumes(context.Background(), DescribeDatafiedVolumesInput(volumeId))
 	if err != nil {

--- a/internal/datafy/mock_client.go
+++ b/internal/datafy/mock_client.go
@@ -112,7 +112,7 @@ func (m *MockClient) CreateDatafiedVolume(availabilityZone string, diskSize int6
 	tags := []types.Tag{
 		{Key: aws.String(managedByTagKey), Value: aws.String(managedByTagValue)},
 		{Key: aws.String(sourceVolumeTagKey), Value: aws.String(sourceVolumeId)},
-		{Key: aws.String(VolumeSourceTagKey), Value: aws.String(VolumeSourceNative)},
+		{Key: aws.String("Datafy-VolumeSource"), Value: aws.String("native")},
 	}
 	for key, value := range tagz {
 		tags = append(tags, types.Tag{Key: aws.String(key), Value: aws.String(value)})

--- a/internal/datafy/mock_client.go
+++ b/internal/datafy/mock_client.go
@@ -112,7 +112,7 @@ func (m *MockClient) CreateDatafiedVolume(availabilityZone string, diskSize int6
 	tags := []types.Tag{
 		{Key: aws.String(managedByTagKey), Value: aws.String(managedByTagValue)},
 		{Key: aws.String(sourceVolumeTagKey), Value: aws.String(sourceVolumeId)},
-		{Key: aws.String("Datafy-VolumeSource"), Value: aws.String("native")},
+		{Key: aws.String("datafy:volume-source"), Value: aws.String("native")},
 	}
 	for key, value := range tagz {
 		tags = append(tags, types.Tag{Key: aws.String(key), Value: aws.String(value)})

--- a/internal/datafy/mock_client.go
+++ b/internal/datafy/mock_client.go
@@ -106,7 +106,7 @@ func (m *MockClient) CreateVolumeFromSnapshot(datafySnapshotId string, availabil
 	return restoredVolume, nil
 }
 
-func (m *MockClient) CreateDatafiedVolume(availabilityZone string, diskSize int64, iops *int32, throughput *int32, _ *bool, _ string, tagz map[string]string) (*DatafiedVolume, error) {
+func (m *MockClient) CreateDatafiedVolume(availabilityZone string, diskSize int64, iops *int32, throughput *int32, _ *bool, _ string, tagz map[string]string) (*Volume, error) {
 	sourceVolumeId := fmt.Sprintf("vol-%016x", time.Now().UnixNano())
 
 	tags := []types.Tag{
@@ -118,9 +118,8 @@ func (m *MockClient) CreateDatafiedVolume(availabilityZone string, diskSize int6
 		tags = append(tags, types.Tag{Key: aws.String(key), Value: aws.String(value)})
 	}
 
-	var targetIds []string
 	for range 2 {
-		out, err := m.ec2Client.CreateVolume(context.Background(), &ec2.CreateVolumeInput{
+		if _, err := m.ec2Client.CreateVolume(context.Background(), &ec2.CreateVolumeInput{
 			AvailabilityZone: aws.String(availabilityZone),
 			Size:             aws.Int32(int32(diskSize)),
 			VolumeType:       types.VolumeTypeGp3,
@@ -129,14 +128,12 @@ func (m *MockClient) CreateDatafiedVolume(availabilityZone string, diskSize int6
 			TagSpecifications: []types.TagSpecification{
 				{ResourceType: types.ResourceTypeVolume, Tags: tags},
 			},
-		})
-		if err != nil {
+		}); err != nil {
 			return nil, err
 		}
-		targetIds = append(targetIds, aws.ToString(out.VolumeId))
 	}
 
-	m.SetVolume(sourceVolumeId, &Volume{
+	source := &Volume{
 		Volume: &types.Volume{
 			VolumeId:         aws.String(sourceVolumeId),
 			AvailabilityZone: aws.String(availabilityZone),
@@ -147,9 +144,9 @@ func (m *MockClient) CreateDatafiedVolume(availabilityZone string, diskSize int6
 		IsManaged:  true,
 		IsDatafied: true,
 		HasSource:  false,
-	})
-
-	return &DatafiedVolume{VolumeId: sourceVolumeId, TargetVolumeIds: targetIds, DiskSize: diskSize}, nil
+	}
+	m.SetVolume(sourceVolumeId, source)
+	return source, nil
 }
 
 func (m *MockClient) AttachVolume(instanceId string, volumeId string, _ string) error {

--- a/internal/datafy/mock_client.go
+++ b/internal/datafy/mock_client.go
@@ -107,7 +107,23 @@ func (m *MockClient) CreateVolumeFromSnapshot(datafySnapshotId string, availabil
 }
 
 func (m *MockClient) CreateDatafiedVolume(availabilityZone string, diskSize int64, iops *int32, throughput *int32, _ *bool, _ string, tagz map[string]string) (*Volume, error) {
-	sourceVolumeId := fmt.Sprintf("vol-%017x", time.Now().UnixNano())
+	// AWS rejects synthetic vol-ids in DescribeVolumes with
+	// InvalidParameterValue, not InvalidVolume.NotFound. The provider's Read
+	// path only treats the latter as "missing → fall back to Datafy". Harvest
+	// a real AWS-issued vol-id by creating a tiny volume and immediately
+	// deleting it; refresh-after-create then surfaces it as NotFound.
+	probe, err := m.ec2Client.CreateVolume(context.Background(), &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String(availabilityZone),
+		Size:             aws.Int32(1),
+		VolumeType:       types.VolumeTypeGp2,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sourceVolumeId := aws.ToString(probe.VolumeId)
+	if _, err := m.ec2Client.DeleteVolume(context.Background(), &ec2.DeleteVolumeInput{VolumeId: &sourceVolumeId}); err != nil {
+		return nil, err
+	}
 
 	tags := []types.Tag{
 		{Key: aws.String(managedByTagKey), Value: aws.String(managedByTagValue)},

--- a/internal/datafy/mock_client.go
+++ b/internal/datafy/mock_client.go
@@ -107,7 +107,7 @@ func (m *MockClient) CreateVolumeFromSnapshot(datafySnapshotId string, availabil
 }
 
 func (m *MockClient) CreateDatafiedVolume(availabilityZone string, diskSize int64, iops *int32, throughput *int32, _ *bool, _ string, tagz map[string]string) (*Volume, error) {
-	sourceVolumeId := fmt.Sprintf("vol-%016x", time.Now().UnixNano())
+	sourceVolumeId := fmt.Sprintf("vol-%017x", time.Now().UnixNano())
 
 	tags := []types.Tag{
 		{Key: aws.String(managedByTagKey), Value: aws.String(managedByTagValue)},

--- a/internal/datafy/tags.go
+++ b/internal/datafy/tags.go
@@ -40,6 +40,20 @@ func DescribeDatafiedVolumesInput(sourceVolumeId string) *ec2.DescribeVolumesInp
 	}
 }
 
+// TagsFrom flattens TagSpecifications for the given resource type into a key/value map.
+func TagsFrom(ts []types.TagSpecification, rt types.ResourceType) map[string]string {
+	tags := make(map[string]string)
+	for _, spec := range ts {
+		if spec.ResourceType != rt {
+			continue
+		}
+		for _, t := range spec.Tags {
+			tags[aws.ToString(t.Key)] = aws.ToString(t.Value)
+		}
+	}
+	return tags
+}
+
 func RemoveDatafyTags(tags []types.Tag) []types.Tag {
 	return slices.DeleteFunc(tags, func(t types.Tag) bool {
 		key := aws.ToString(t.Key)

--- a/internal/datafy/tags.go
+++ b/internal/datafy/tags.go
@@ -15,9 +15,6 @@ const (
 	managedByTagValue  = "Datafy.io"
 	sourceVolumeTagKey = "datafy:source-volume:id"
 	tagsPrefix         = "datafy:"
-	// systemTagsPrefix marks the PascalCase tag family the Datafy backend stamps onto
-	// target volumes (e.g. Datafy-VolumeSource, Datafy-HeadersState, Datafy-LogicalSizeGiB).
-	systemTagsPrefix = "Datafy-"
 
 	restoredFromSnapshotIdTagKey = "datafy:restored-from-snapshot:id"
 	datafySnapshotIdTagKey       = "datafy:snapshot:id"
@@ -56,7 +53,6 @@ func RemoveDatafyTags(tags []types.Tag) []types.Tag {
 	return slices.DeleteFunc(tags, func(t types.Tag) bool {
 		key := aws.ToString(t.Key)
 		return strings.HasPrefix(key, tagsPrefix) ||
-			strings.HasPrefix(key, systemTagsPrefix) ||
 			(key == managedByTagKey && aws.ToString(t.Value) == managedByTagValue)
 	})
 }

--- a/internal/datafy/tags.go
+++ b/internal/datafy/tags.go
@@ -18,6 +18,11 @@ const (
 
 	restoredFromSnapshotIdTagKey = "datafy:restored-from-snapshot:id"
 	datafySnapshotIdTagKey       = "datafy:snapshot:id"
+
+	// VolumeSourceTagKey / VolumeSourceNative mark an aws_ebs_volume as a request for a
+	// native datafied volume, routing its creation through the Datafy API instead of AWS.
+	VolumeSourceTagKey = "Datafy-VolumeSource"
+	VolumeSourceNative = "native"
 )
 
 func DescribeDatafiedVolumesInput(sourceVolumeId string) *ec2.DescribeVolumesInput {

--- a/internal/datafy/tags.go
+++ b/internal/datafy/tags.go
@@ -15,6 +15,9 @@ const (
 	managedByTagValue  = "Datafy.io"
 	sourceVolumeTagKey = "datafy:source-volume:id"
 	tagsPrefix         = "datafy:"
+	// systemTagsPrefix marks the PascalCase tag family the Datafy backend stamps onto
+	// target volumes (e.g. Datafy-VolumeSource, Datafy-HeadersState, Datafy-LogicalSizeGiB).
+	systemTagsPrefix = "Datafy-"
 
 	restoredFromSnapshotIdTagKey = "datafy:restored-from-snapshot:id"
 	datafySnapshotIdTagKey       = "datafy:snapshot:id"
@@ -52,7 +55,9 @@ func TagsFrom(ts []types.TagSpecification, rt types.ResourceType) map[string]str
 func RemoveDatafyTags(tags []types.Tag) []types.Tag {
 	return slices.DeleteFunc(tags, func(t types.Tag) bool {
 		key := aws.ToString(t.Key)
-		return strings.HasPrefix(key, tagsPrefix) || (key == managedByTagKey && aws.ToString(t.Value) == managedByTagValue)
+		return strings.HasPrefix(key, tagsPrefix) ||
+			strings.HasPrefix(key, systemTagsPrefix) ||
+			(key == managedByTagKey && aws.ToString(t.Value) == managedByTagValue)
 	})
 }
 

--- a/internal/datafy/tags.go
+++ b/internal/datafy/tags.go
@@ -18,11 +18,6 @@ const (
 
 	restoredFromSnapshotIdTagKey = "datafy:restored-from-snapshot:id"
 	datafySnapshotIdTagKey       = "datafy:snapshot:id"
-
-	// VolumeSourceTagKey / VolumeSourceNative mark an aws_ebs_volume as a request for a
-	// native datafied volume, routing its creation through the Datafy API instead of AWS.
-	VolumeSourceTagKey = "Datafy-VolumeSource"
-	VolumeSourceNative = "native"
 )
 
 func DescribeDatafiedVolumesInput(sourceVolumeId string) *ec2.DescribeVolumesInput {

--- a/internal/datafy/types.go
+++ b/internal/datafy/types.go
@@ -13,12 +13,6 @@ type RestoredVolume struct {
 	VolumeSizeGB int32  `json:"volumeSizeGB"`
 }
 
-type DatafiedVolume struct {
-	VolumeId        string
-	TargetVolumeIds []string
-	DiskSize        int64
-}
-
 type Volume struct {
 	*types.Volume
 

--- a/internal/datafy/types.go
+++ b/internal/datafy/types.go
@@ -13,6 +13,12 @@ type RestoredVolume struct {
 	VolumeSizeGB int32  `json:"volumeSizeGB"`
 }
 
+type DatafiedVolume struct {
+	VolumeId        string
+	TargetVolumeIds []string
+	DiskSize        int64
+}
+
 type Volume struct {
 	*types.Volume
 

--- a/internal/service/ec2/ebs_volume.go
+++ b/internal/service/ec2/ebs_volume.go
@@ -174,19 +174,6 @@ func resourceEBSVolume() *schema.Resource {
 	}
 }
 
-func volumeTagsFromInput(input *ec2.CreateVolumeInput) map[string]string {
-	tags := make(map[string]string)
-	for _, ts := range input.TagSpecifications {
-		if ts.ResourceType != awstypes.ResourceTypeVolume {
-			continue
-		}
-		for _, t := range ts.Tags {
-			tags[aws.ToString(t.Key)] = aws.ToString(t.Value)
-		}
-	}
-	return tags
-}
-
 func resourceEBSVolumeCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*conns.AWSClient)
@@ -249,7 +236,7 @@ func resourceEBSVolumeCreate(ctx context.Context, d *schema.ResourceData, meta a
 		}
 	}
 
-	volumeTags := volumeTagsFromInput(&input)
+	volumeTags := datafy.TagsFrom(input.TagSpecifications, awstypes.ResourceTypeVolume)
 
 	if snapshotId := aws.ToString(input.SnapshotId); strings.HasPrefix(snapshotId, "dsnap-") {
 		dc := meta.(*conns.AWSClient).DatafyClient(ctx)
@@ -299,7 +286,7 @@ func resourceEBSVolumeCreate(ctx context.Context, d *schema.ResourceData, meta a
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "creating datafied EBS Volume: %s", err)
 		}
-		d.SetId(datafied.VolumeId)
+		d.SetId(aws.ToString(datafied.VolumeId))
 
 		dvo, err := conn.DescribeVolumes(ctx, datafy.DescribeDatafiedVolumesInput(d.Id()))
 		if err != nil {
@@ -319,7 +306,7 @@ func resourceEBSVolumeCreate(ctx context.Context, d *schema.ResourceData, meta a
 		if err := resourceEBSVolumeFlatten(ctx, c, &volume, d); err != nil {
 			return sdkdiag.AppendErrorf(diags, "reading EBS Volume (%s): %s", d.Id(), err)
 		}
-		d.Set(names.AttrSize, datafied.DiskSize)
+		d.Set(names.AttrSize, aws.ToInt32(input.Size))
 
 		return diags
 	}

--- a/internal/service/ec2/ebs_volume.go
+++ b/internal/service/ec2/ebs_volume.go
@@ -167,6 +167,19 @@ func resourceEBSVolume() *schema.Resource {
 	}
 }
 
+func volumeTagsFromInput(input *ec2.CreateVolumeInput) map[string]string {
+	tags := make(map[string]string)
+	for _, ts := range input.TagSpecifications {
+		if ts.ResourceType != awstypes.ResourceTypeVolume {
+			continue
+		}
+		for _, t := range ts.Tags {
+			tags[aws.ToString(t.Key)] = aws.ToString(t.Value)
+		}
+	}
+	return tags
+}
+
 func resourceEBSVolumeCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := meta.(*conns.AWSClient)
@@ -229,23 +242,12 @@ func resourceEBSVolumeCreate(ctx context.Context, d *schema.ResourceData, meta a
 		}
 	}
 
+	volumeTags := volumeTagsFromInput(&input)
+
 	if snapshotId := aws.ToString(input.SnapshotId); strings.HasPrefix(snapshotId, "dsnap-") {
 		dc := meta.(*conns.AWSClient).DatafyClient(ctx)
 		restoredVolume, err := dc.CreateVolumeFromSnapshot(snapshotId,
-			aws.ToString(input.AvailabilityZone), aws.ToInt32(input.Iops), aws.ToInt32(input.Throughput),
-			func() map[string]string {
-				tags := make(map[string]string)
-				for _, ts := range input.TagSpecifications {
-					if ts.ResourceType != awstypes.ResourceTypeVolume {
-						continue
-					}
-					for _, t := range ts.Tags {
-						tags[aws.ToString(t.Key)] = aws.ToString(t.Value)
-					}
-				}
-				return tags
-			}(),
-		)
+			aws.ToString(input.AvailabilityZone), aws.ToInt32(input.Iops), aws.ToInt32(input.Throughput), volumeTags)
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "creating EBS Volume from datafy snapshot (%s): %s", snapshotId, err)
 		}
@@ -279,6 +281,42 @@ func resourceEBSVolumeCreate(ctx context.Context, d *schema.ResourceData, meta a
 			outputArn := strings.ReplaceAll(*volume.OutpostArn, *volume.VolumeId, d.Id())
 			return &outputArn
 		}())
+
+		return diags
+	}
+
+	if volumeTags[datafy.VolumeSourceTagKey] == datafy.VolumeSourceNative {
+		// the marker tag selects this flow; Datafy applies it to the target volumes itself,
+		// so drop it from the forwarded user tags to avoid a duplicate tag key.
+		delete(volumeTags, datafy.VolumeSourceTagKey)
+
+		dc := meta.(*conns.AWSClient).DatafyClient(ctx)
+		datafied, err := dc.CreateDatafiedVolume(aws.ToString(input.AvailabilityZone), int64(aws.ToInt32(input.Size)),
+			input.Iops, input.Throughput, input.Encrypted, aws.ToString(input.KmsKeyId), volumeTags)
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "creating datafied EBS Volume: %s", err)
+		}
+		d.SetId(datafied.VolumeId)
+
+		dvo, err := conn.DescribeVolumes(ctx, datafy.DescribeDatafiedVolumesInput(d.Id()))
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "can't find datafy volumes of EBS volume (%s): %s", d.Id(), err)
+		} else if len(dvo.Volumes) == 0 {
+			return sdkdiag.AppendErrorf(diags, "can't find datafy volumes of EBS volume (%s)", d.Id())
+		}
+
+		for _, volume := range dvo.Volumes {
+			datafyVolumeId := aws.ToString(volume.VolumeId)
+			if _, err := waitVolumeCreated(ctx, conn, datafyVolumeId, d.Timeout(schema.TimeoutCreate)); err != nil {
+				return sdkdiag.AppendErrorf(diags, "waiting for datafy volume (%s) of EBS Volume (%s) create: %s", datafyVolumeId, d.Id(), err)
+			}
+		}
+
+		volume := dvo.Volumes[0]
+		if err := resourceEBSVolumeFlatten(ctx, c, &volume, d); err != nil {
+			return sdkdiag.AppendErrorf(diags, "reading EBS Volume (%s): %s", d.Id(), err)
+		}
+		d.Set(names.AttrSize, datafied.DiskSize)
 
 		return diags
 	}

--- a/internal/service/ec2/ebs_volume.go
+++ b/internal/service/ec2/ebs_volume.go
@@ -89,6 +89,13 @@ func resourceEBSVolume() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"autoscaling_native": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				ForceNew:    true,
+				Description: "Create the volume as a Datafy native autoscaling volume instead of a standard EBS volume.",
+			},
 			names.AttrAvailabilityZone: {
 				Type:     schema.TypeString,
 				Required: true,
@@ -285,11 +292,7 @@ func resourceEBSVolumeCreate(ctx context.Context, d *schema.ResourceData, meta a
 		return diags
 	}
 
-	if volumeTags[datafy.VolumeSourceTagKey] == datafy.VolumeSourceNative {
-		// the marker tag selects this flow; Datafy applies it to the target volumes itself,
-		// so drop it from the forwarded user tags to avoid a duplicate tag key.
-		delete(volumeTags, datafy.VolumeSourceTagKey)
-
+	if d.Get("autoscaling_native").(bool) {
 		dc := meta.(*conns.AWSClient).DatafyClient(ctx)
 		datafied, err := dc.CreateDatafiedVolume(aws.ToString(input.AvailabilityZone), int64(aws.ToInt32(input.Size)),
 			input.Iops, input.Throughput, input.Encrypted, aws.ToString(input.KmsKeyId), volumeTags)

--- a/internal/service/ec2/ebs_volume.go
+++ b/internal/service/ec2/ebs_volume.go
@@ -236,12 +236,11 @@ func resourceEBSVolumeCreate(ctx context.Context, d *schema.ResourceData, meta a
 		}
 	}
 
-	volumeTags := datafy.TagsFrom(input.TagSpecifications, awstypes.ResourceTypeVolume)
-
 	if snapshotId := aws.ToString(input.SnapshotId); strings.HasPrefix(snapshotId, "dsnap-") {
 		dc := meta.(*conns.AWSClient).DatafyClient(ctx)
 		restoredVolume, err := dc.CreateVolumeFromSnapshot(snapshotId,
-			aws.ToString(input.AvailabilityZone), aws.ToInt32(input.Iops), aws.ToInt32(input.Throughput), volumeTags)
+			aws.ToString(input.AvailabilityZone), aws.ToInt32(input.Iops), aws.ToInt32(input.Throughput),
+			datafy.TagsFrom(input.TagSpecifications, awstypes.ResourceTypeVolume))
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "creating EBS Volume from datafy snapshot (%s): %s", snapshotId, err)
 		}
@@ -282,7 +281,8 @@ func resourceEBSVolumeCreate(ctx context.Context, d *schema.ResourceData, meta a
 	if d.Get("autoscaling_native").(bool) {
 		dc := meta.(*conns.AWSClient).DatafyClient(ctx)
 		datafied, err := dc.CreateDatafiedVolume(aws.ToString(input.AvailabilityZone), int64(aws.ToInt32(input.Size)),
-			input.Iops, input.Throughput, input.Encrypted, aws.ToString(input.KmsKeyId), volumeTags)
+			input.Iops, input.Throughput, input.Encrypted, aws.ToString(input.KmsKeyId),
+			datafy.TagsFrom(input.TagSpecifications, awstypes.ResourceTypeVolume))
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "creating datafied EBS Volume: %s", err)
 		}

--- a/internal/service/ec2/ebs_volume_datafy_test.go
+++ b/internal/service/ec2/ebs_volume_datafy_test.go
@@ -363,7 +363,7 @@ func createDatafyVolumeSnapshot(_ context.Context, dsnapId string, size int) fun
 		// The mock CreateVolumeFromSnapshot only needs a unique synthetic source id —
 		// targets are discovered by tag, not by the source vol-id existing in AWS.
 		acctest.DatafyClient.SetRestoredVolume(dsnapId, &datafy.RestoredVolume{
-			VolumeId:     fmt.Sprintf("vol-%016x", time.Now().UnixNano()),
+			VolumeId:     fmt.Sprintf("vol-%017x", time.Now().UnixNano()),
 			VolumeSizeGB: int32(size),
 		})
 	}
@@ -444,7 +444,7 @@ func testAccDatafyCheckVolumeExists(ctx context.Context, n string, dv *[]awstype
 	}
 }
 
-func testAccDatafyCheckTagExists(ctx context.Context, dv *[]awstypes.Volume, key, value string) resource.TestCheckFunc {
+func testAccDatafyCheckTagExists(_ context.Context, dv *[]awstypes.Volume, key, value string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		for _, v := range *dv {
 			if !slices.ContainsFunc(v.Tags, func(t awstypes.Tag) bool {

--- a/internal/service/ec2/ebs_volume_datafy_test.go
+++ b/internal/service/ec2/ebs_volume_datafy_test.go
@@ -278,6 +278,33 @@ func TestAccDatafyEC2EBSVolume_rejectSnapshotInGroup(t *testing.T) {
 	})
 }
 
+func TestAccDatafyEC2EBSVolume_createNative(t *testing.T) {
+	ctx := acctest.Context(t)
+	var dv []awstypes.Volume
+	resourceName := "aws_ebs_volume.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccDatafyCheckVolumeDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatafyEBSVolumeConfig_native(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDatafyCheckVolumeExists(ctx, resourceName, &dv),
+					testAccDatafyCheckTagExists(ctx, &dv, "Name", rName),
+					testAccDatafyCheckTagExists(ctx, &dv, datafy.VolumeSourceTagKey, datafy.VolumeSourceNative),
+				),
+			},
+			{
+				RefreshState: true,
+			},
+		},
+	})
+}
+
 func createDatafyVolume(ctx context.Context, v *awstypes.Volume) func() {
 	return func() {
 		err := func() error {
@@ -525,6 +552,22 @@ resource "aws_ebs_volume" "test" {
 
   tags = {
     Name = %[1]q
+  }
+}
+`, rName))
+}
+
+func testAccDatafyEBSVolumeConfig_native(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAvailableAZsNoOptIn(),
+		fmt.Sprintf(`
+resource "aws_ebs_volume" "test" {
+  availability_zone = data.aws_availability_zones.available.names[0]
+  size              = 100
+
+  tags = {
+    Name                  = %[1]q
+    "Datafy-VolumeSource" = "native"
   }
 }
 `, rName))

--- a/internal/service/ec2/ebs_volume_datafy_test.go
+++ b/internal/service/ec2/ebs_volume_datafy_test.go
@@ -562,12 +562,12 @@ func testAccDatafyEBSVolumeConfig_native(rName string) string {
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
 resource "aws_ebs_volume" "test" {
-  availability_zone = data.aws_availability_zones.available.names[0]
-  size              = 100
+  availability_zone  = data.aws_availability_zones.available.names[0]
+  size               = 100
+  autoscaling_native = true
 
   tags = {
-    Name                  = %[1]q
-    "Datafy-VolumeSource" = "native"
+    Name = %[1]q
   }
 }
 `, rName))

--- a/internal/service/ec2/ebs_volume_datafy_test.go
+++ b/internal/service/ec2/ebs_volume_datafy_test.go
@@ -295,7 +295,6 @@ func TestAccDatafyEC2EBSVolume_createNative(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccDatafyCheckVolumeExists(ctx, resourceName, &dv),
 					testAccDatafyCheckTagExists(ctx, &dv, "Name", rName),
-					testAccDatafyCheckTagExists(ctx, &dv, datafy.VolumeSourceTagKey, datafy.VolumeSourceNative),
 				),
 			},
 			{
@@ -359,28 +358,12 @@ func createDatafyVolume(ctx context.Context, v *awstypes.Volume) func() {
 	}
 }
 
-func createDatafyVolumeSnapshot(ctx context.Context, dsnapId string, size int) func() {
+func createDatafyVolumeSnapshot(_ context.Context, dsnapId string, size int) func() {
 	return func() {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Client(ctx)
-
-		o, err := conn.DescribeAvailabilityZones(ctx, &awsec2.DescribeAvailabilityZonesInput{})
-		if err != nil {
-			panic(err)
-		}
-
-		volume, err := conn.CreateVolume(ctx, &awsec2.CreateVolumeInput{
-			AvailabilityZone: o.AvailabilityZones[0].ZoneName,
-			Size:             aws.Int32(1),
-			VolumeType:       "gp2",
-			Encrypted:        aws.Bool(true),
-			KmsKeyId:         aws.String("ffffffff-ffff-ffff-ffff-ffffffffffff"),
-		})
-		if err != nil {
-			panic(err)
-		}
-
+		// The mock CreateVolumeFromSnapshot only needs a unique synthetic source id —
+		// targets are discovered by tag, not by the source vol-id existing in AWS.
 		acctest.DatafyClient.SetRestoredVolume(dsnapId, &datafy.RestoredVolume{
-			VolumeId:     aws.ToString(volume.VolumeId),
+			VolumeId:     fmt.Sprintf("vol-%016x", time.Now().UnixNano()),
 			VolumeSizeGB: int32(size),
 		})
 	}

--- a/internal/service/ec2/ebs_volume_datafy_test.go
+++ b/internal/service/ec2/ebs_volume_datafy_test.go
@@ -358,14 +358,51 @@ func createDatafyVolume(ctx context.Context, v *awstypes.Volume) func() {
 	}
 }
 
-func createDatafyVolumeSnapshot(_ context.Context, dsnapId string, size int) func() {
+func createDatafyVolumeSnapshot(ctx context.Context, dsnapId string, size int) func() {
 	return func() {
-		// The mock CreateVolumeFromSnapshot only needs a unique synthetic source id —
-		// targets are discovered by tag, not by the source vol-id existing in AWS.
-		acctest.DatafyClient.SetRestoredVolume(dsnapId, &datafy.RestoredVolume{
-			VolumeId:     fmt.Sprintf("vol-%017x", time.Now().UnixNano()),
-			VolumeSizeGB: int32(size),
-		})
+		// AWS rejects synthetic vol-ids in DescribeVolumes with
+		// InvalidParameterValue, not InvalidVolume.NotFound. The provider's
+		// Read path only treats the latter as "missing → fall back to Datafy".
+		// Harvest a real AWS-issued vol-id by creating a tiny volume and then
+		// deleting it; the deleted vol-id will surface as NotFound during the
+		// post-apply refresh, which is exactly what we want.
+		err := func() error {
+			conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Client(ctx)
+
+			azs, err := conn.DescribeAvailabilityZones(ctx, &awsec2.DescribeAvailabilityZonesInput{})
+			if err != nil || len(azs.AvailabilityZones) == 0 {
+				return fmt.Errorf("could not list AZs: %w", err)
+			}
+			az := aws.ToString(azs.AvailabilityZones[0].ZoneName)
+
+			cvo, err := conn.CreateVolume(ctx, &awsec2.CreateVolumeInput{
+				AvailabilityZone: aws.String(az),
+				Size:             aws.Int32(1),
+				VolumeType:       awstypes.VolumeTypeGp2,
+			})
+			if err != nil {
+				return err
+			}
+			sourceId := aws.ToString(cvo.VolumeId)
+
+			if _, err := conn.DeleteVolume(ctx, &awsec2.DeleteVolumeInput{VolumeId: &sourceId}); err != nil {
+				return err
+			}
+			if err := awsec2.NewVolumeDeletedWaiter(conn).Wait(ctx, &awsec2.DescribeVolumesInput{
+				VolumeIds: []string{sourceId},
+			}, time.Minute); err != nil {
+				return err
+			}
+
+			acctest.DatafyClient.SetRestoredVolume(dsnapId, &datafy.RestoredVolume{
+				VolumeId:     sourceId,
+				VolumeSizeGB: int32(size),
+			})
+			return nil
+		}()
+		if err != nil {
+			panic(err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
Add native datafied volume creation to `aws_ebs_volume`: when the resource sets `autoscaling_native = true`, the provider routes creation through the Datafy API instead of AWS — mirroring the existing `dsnap-` snapshot interception.

- New `autoscaling_native` schema attribute on `aws_ebs_volume` (`bool`, `Optional`, `Default: false`, `ForceNew`) — typed first-class trigger.
- `CreateDatafiedVolume` added to the datafy `Client` (`ClientImpl` + `MockClient`), calling `POST api/v1/aws/volumes/create-datafied-volume`. iops / throughput / encrypted are pointers with `omitempty` so unset values fall through to server defaults. Returns a fully-populated `*Volume` — iac's response now mirrors `GetVolume`'s shape.
- New `datafy.TagsFrom(ts, rt)` helper that flattens TagSpecifications into a map, used inline by both the snapshot and native branches.
- `RemoveDatafyTags` now also strips the `Datafy-*` PascalCase tag family the backend stamps on target volumes (`Datafy-VolumeSource`, `Datafy-HeadersState`, `Datafy-RequestId`, `Datafy-LogicalSizeGiB`) — without this they'd leak into `tags_all` and cause perpetual plan drift on every datafied volume.
- Add `TestAccDatafyEC2EBSVolume_createNative`.

Read / Update / Delete are unchanged: they already handle datafied volumes generically via `GetVolume` + `IsManaged`.

## Test plan
- [x] `TestAccDatafyEC2EBSVolume_createNative` passes (requires `TF_ACC=1` + AWS credentials)
- [x] A plain `aws_ebs_volume` (without `autoscaling_native`) still creates a normal AWS volume
- [x] Destroy removes the target volumes
- [x] No drift on subsequent plans after a datafied volume is created