### PR TITLE
datafy: fix markdown lint violations in agents.md

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -21,6 +21,7 @@ All Datafy additions live in `internal/datafy/` and in targeted overrides inside
 ### Why this wrapper exists — the datafied volume problem
 
 When Datafy runs its **datafy action** on an EBS volume it:
+
 1. Deletes the original (source) volume from AWS.
 2. Creates **new Datafy-managed volumes** in its place (the "datafy volumes"), identified by a tag that links them back to the original volume ID.
 
@@ -32,25 +33,30 @@ This provider intercepts every EBS operation and routes it through the **Datafy 
 
 ### How the EBS Volume resource works (`ebs_volume.go`)
 
-**CustomizeDiff — blocking unsupported changes**
+#### CustomizeDiff — blocking unsupported changes
+
 Before planning any change to a volume, the provider checks with the Datafy API. If the volume is managed, only `size`, `iops`, and `throughput` are allowed to change. Any other attribute change (type, encryption, AZ, etc.) is rejected with an error at plan time — Terraform never even attempts the apply.
 
-**Read**
+#### Read
+
 - If the volume exists in AWS → normal read.
 - If the volume is **not found in AWS** (because it was datafied and deleted):
-  - If Datafy reports it as **managed**: return the current Terraform state unchanged, updating only `size`/`iops`/`throughput`/`tags` from the Datafy API and the underlying datafy volumes. Terraform sees no drift.
-  - If Datafy reports it as **replaced** (`ReplacedBy` is set, meaning it was un-datafied and a fresh AWS volume was created): update the state ID to the new volume and re-read from AWS, handing control back to Terraform.
+    - If Datafy reports it as **managed**: return the current Terraform state unchanged, updating only `size`/`iops`/`throughput`/`tags` from the Datafy API and the underlying datafy volumes. Terraform sees no drift.
+    - If Datafy reports it as **replaced** (`ReplacedBy` is set, meaning it was un-datafied and a fresh AWS volume was created): update the state ID to the new volume and re-read from AWS, handing control back to Terraform.
 
-**Create**
+#### Create
+
 - Snapshot IDs starting with `dsnap-` are Datafy snapshots. The provider calls `dc.CreateVolumeFromSnapshot` instead of the AWS API, then waits for the resulting datafy volumes to become available.
 - Normal `snap-` and non-snapshot creates go straight to AWS.
 
-**Update**
+#### Update
+
 - Managed volume: only `size`, `iops`, `throughput` changes are forwarded to `dc.ModifyVolume` (Datafy API). The provider then polls until the Datafy API confirms the new value.
 - Replaced volume: redirects to the new volume ID and retries the update against AWS normally.
 - Unmanaged volume: standard AWS `ModifyVolume`.
 
-**Delete**
+#### Delete
+
 - Managed volume: collect the IDs of all underlying datafy volumes (and the source, if it still exists) and delete them all. The Datafy API controls snapshots and cleanup on its side.
 - Replaced volume: redirects to the new volume ID and deletes it normally.
 - Unmanaged volume: standard AWS `DeleteVolume`, with optional `final_snapshot` support.
@@ -59,18 +65,22 @@ Before planning any change to a volume, the provider checks with the Datafy API.
 
 ### How the EBS Volume Attachment resource works (`ebs_volume_attachment.go`)
 
-**CustomizeDiff — blocking changes**
+#### CustomizeDiff — blocking changes
+
 Any modification to an existing volume attachment whose volume is managed is rejected at plan time.
 
-**Create**
+#### Create
+
 - If the volume is managed, calls `dc.AttachVolume` (Datafy API) instead of the AWS API. The Datafy service attaches all underlying datafy volumes to the instance. The provider then waits for each of them to reach the attached state in AWS.
 - Unmanaged: standard AWS `AttachVolume`.
 
-**Read**
+#### Read
+
 - If the attachment is not found in AWS and the volume is managed: the attachment is under Datafy's control — return the existing state unchanged (no drift).
 - If the volume has been replaced: update `volume_id` in state to the new ID and re-read.
 
-**Delete**
+#### Delete
+
 - Managed volume: calls `dc.DetachVolume` (Datafy API), which detaches all underlying datafy volumes. The provider waits for every volume to reach the detached state in AWS.
 - Replaced volume: redirects to the new volume ID and detaches normally.
 - Unmanaged: standard AWS `DetachVolume`, with optional `stop_instance_before_detaching`.
@@ -88,4 +98,3 @@ Any modification to an existing volume attachment whose volume is managed is rej
 | **ReplacedBy** | Set when a volume is un-datafied — contains the ID of the new AWS volume that replaces it. Signals Terraform to hand control back to AWS. |
 | **dsnap- prefix** | Datafy snapshot IDs (vs AWS `snap-` prefix). Creating a volume from a `dsnap-` snapshot is routed through the Datafy API. |
 | **Datafy client** | `internal/datafy.Client` — thin HTTP client to the Datafy SaaS API. Obtained via `meta.(*conns.AWSClient).DatafyClient(ctx)`. |
-


### PR DESCRIPTION
## Summary
`agents.md` (added in the initial Datafy commit) trips the `Markdown lint` workflow with these rules:

- **MD036** — emphasis used as heading (`**Read**`, `**Create**`, ...). Converted to proper `####` headings.
- **MD032** — lists missing surrounding blank lines. Added blanks above each list.
- **MD007** — sub-list indentation expected 4 spaces, was 2. Fixed.
- **MD012** — extra trailing blank line at EOF. Removed.

No content changes — purely formatting fixes.

## Why now
The `Markdown lint` workflow only runs on PRs, so these latent violations don't fail anything on `release/4.x` itself, but they fail every PR opened against it. Landing this small fix unblocks all those PRs.

Backport of #48 (release/6.x).

## Test plan
- [ ] `Markdown lint` job passes in this PR's CI