### PR TITLE
DT-9731: [DT-10524] port autoscaling_native create path to release/5.x

### DIFF
--- a/internal/datafy/client.go
+++ b/internal/datafy/client.go
@@ -15,6 +15,7 @@ const DefaultUrl = "https://iac.datafy.io"
 type Client interface {
 	GetVolume(volumeId string) (*Volume, error)
 	CreateVolumeFromSnapshot(datafySnapshotId string, availabilityZone string, iops int32, throughput int32, tagz map[string]string) (*RestoredVolume, error)
+	CreateDatafiedVolume(availabilityZone string, diskSize int64, iops *int32, throughput *int32, encrypted *bool, kmsKeyId string, tagz map[string]string) (*Volume, error)
 	AttachVolume(instanceId string, volumeId string, deviceName string) error
 	DetachVolume(instanceId string, volumeId string) error
 	ModifyVolume(volumeId string, sizeGb *int32, iops *int32, throughput *int32) error
@@ -40,6 +41,20 @@ type createFromSnapshotsVolumeProperties struct {
 type createFromSnapshotsRequest struct {
 	Source           createFromSnapshotsSource           `json:"source"`
 	VolumeProperties createFromSnapshotsVolumeProperties `json:"volumeProperties"`
+}
+
+type createDatafiedVolumeProperties struct {
+	AvailabilityZone string `json:"availabilityZone"`
+	DiskSize         int64  `json:"diskSize"`
+	VolumeIops       *int32 `json:"volumeIops,omitempty"`
+	VolumeThroughput *int32 `json:"volumeThroughput,omitempty"`
+	Encrypted        *bool  `json:"encrypted,omitempty"`
+	KmsKeyId         string `json:"kmsKeyId,omitempty"`
+	Tags             []tags `json:"tags,omitempty"`
+}
+
+type createDatafiedVolumeRequest struct {
+	VolumeProperties createDatafiedVolumeProperties `json:"volumeProperties"`
 }
 
 type attachVolumeRequest struct {
@@ -153,6 +168,40 @@ func (c *ClientImpl) CreateVolumeFromSnapshot(datafySnapshotId string, availabil
 
 	if resp.StatusCode == http.StatusOK {
 		var out RestoredVolume
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			return nil, err
+		}
+		return &out, nil
+	}
+
+	return nil, toError(resp)
+}
+
+func (c *ClientImpl) CreateDatafiedVolume(availabilityZone string, diskSize int64, iops *int32, throughput *int32, encrypted *bool, kmsKeyId string, tagz map[string]string) (*Volume, error) {
+	tagsList := make([]tags, 0, len(tagz))
+	for k, v := range tagz {
+		tagsList = append(tagsList, tags{Key: k, Value: v})
+	}
+	request := createDatafiedVolumeRequest{
+		VolumeProperties: createDatafiedVolumeProperties{
+			AvailabilityZone: availabilityZone,
+			DiskSize:         diskSize,
+			VolumeIops:       iops,
+			VolumeThroughput: throughput,
+			Encrypted:        encrypted,
+			KmsKeyId:         kmsKeyId,
+			Tags:             tagsList,
+		},
+	}
+
+	resp, err := c.sendRequest(http.MethodPost, "api/v1/aws/volumes/create-autoscaling-volume", request)
+	if err != nil {
+		return nil, err
+	}
+	defer drain(resp)
+
+	if resp.StatusCode == http.StatusOK {
+		var out Volume
 		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 			return nil, err
 		}

--- a/internal/datafy/mock_client.go
+++ b/internal/datafy/mock_client.go
@@ -106,6 +106,65 @@ func (m *MockClient) CreateVolumeFromSnapshot(datafySnapshotId string, availabil
 	return restoredVolume, nil
 }
 
+func (m *MockClient) CreateDatafiedVolume(availabilityZone string, diskSize int64, iops *int32, throughput *int32, _ *bool, _ string, tagz map[string]string) (*Volume, error) {
+	// AWS rejects synthetic vol-ids in DescribeVolumes with
+	// InvalidParameterValue, not InvalidVolume.NotFound. The provider's Read
+	// path only treats the latter as "missing → fall back to Datafy". Harvest
+	// a real AWS-issued vol-id by creating a tiny volume and immediately
+	// deleting it; refresh-after-create then surfaces it as NotFound.
+	probe, err := m.ec2Client.CreateVolume(context.Background(), &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String(availabilityZone),
+		Size:             aws.Int32(1),
+		VolumeType:       types.VolumeTypeGp2,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sourceVolumeId := aws.ToString(probe.VolumeId)
+	if _, err := m.ec2Client.DeleteVolume(context.Background(), &ec2.DeleteVolumeInput{VolumeId: &sourceVolumeId}); err != nil {
+		return nil, err
+	}
+
+	tags := []types.Tag{
+		{Key: aws.String(managedByTagKey), Value: aws.String(managedByTagValue)},
+		{Key: aws.String(sourceVolumeTagKey), Value: aws.String(sourceVolumeId)},
+		{Key: aws.String("datafy:volume-source"), Value: aws.String("native")},
+	}
+	for key, value := range tagz {
+		tags = append(tags, types.Tag{Key: aws.String(key), Value: aws.String(value)})
+	}
+
+	for range 2 {
+		if _, err := m.ec2Client.CreateVolume(context.Background(), &ec2.CreateVolumeInput{
+			AvailabilityZone: aws.String(availabilityZone),
+			Size:             aws.Int32(int32(diskSize)),
+			VolumeType:       types.VolumeTypeGp3,
+			Iops:             iops,
+			Throughput:       throughput,
+			TagSpecifications: []types.TagSpecification{
+				{ResourceType: types.ResourceTypeVolume, Tags: tags},
+			},
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	source := &Volume{
+		Volume: &types.Volume{
+			VolumeId:         aws.String(sourceVolumeId),
+			AvailabilityZone: aws.String(availabilityZone),
+			Size:             aws.Int32(int32(diskSize)),
+			Iops:             iops,
+			Throughput:       throughput,
+		},
+		IsManaged:  true,
+		IsDatafied: true,
+		HasSource:  false,
+	}
+	m.SetVolume(sourceVolumeId, source)
+	return source, nil
+}
+
 func (m *MockClient) AttachVolume(instanceId string, volumeId string, _ string) error {
 	dvo, err := m.ec2Client.DescribeVolumes(context.Background(), DescribeDatafiedVolumesInput(volumeId))
 	if err != nil {

--- a/internal/datafy/tags.go
+++ b/internal/datafy/tags.go
@@ -35,6 +35,20 @@ func DescribeDatafiedVolumesInput(sourceVolumeId string) *ec2.DescribeVolumesInp
 	}
 }
 
+// TagsFrom flattens TagSpecifications for the given resource type into a key/value map.
+func TagsFrom(ts []types.TagSpecification, rt types.ResourceType) map[string]string {
+	tags := make(map[string]string)
+	for _, spec := range ts {
+		if spec.ResourceType != rt {
+			continue
+		}
+		for _, t := range spec.Tags {
+			tags[aws.ToString(t.Key)] = aws.ToString(t.Value)
+		}
+	}
+	return tags
+}
+
 func RemoveDatafyTags(tags []types.Tag) []types.Tag {
 	return slices.DeleteFunc(tags, func(t types.Tag) bool {
 		key := aws.ToString(t.Key)

--- a/internal/service/ec2/ebs_volume.go
+++ b/internal/service/ec2/ebs_volume.go
@@ -85,6 +85,13 @@ func resourceEBSVolume() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"autoscaling_native": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				ForceNew:    true,
+				Description: "Create the volume as a Datafy native autoscaling volume instead of a standard EBS volume.",
+			},
 			names.AttrAvailabilityZone: {
 				Type:     schema.TypeString,
 				Required: true,
@@ -219,19 +226,7 @@ func resourceEBSVolumeCreate(ctx context.Context, d *schema.ResourceData, meta a
 		dc := meta.(*conns.AWSClient).DatafyClient(ctx)
 		restoredVolume, err := dc.CreateVolumeFromSnapshot(snapshotId,
 			aws.ToString(input.AvailabilityZone), aws.ToInt32(input.Iops), aws.ToInt32(input.Throughput),
-			func() map[string]string {
-				tags := make(map[string]string)
-				for _, ts := range input.TagSpecifications {
-					if ts.ResourceType != awstypes.ResourceTypeVolume {
-						continue
-					}
-					for _, t := range ts.Tags {
-						tags[aws.ToString(t.Key)] = aws.ToString(t.Value)
-					}
-				}
-				return tags
-			}(),
-		)
+			datafy.TagsFrom(input.TagSpecifications, awstypes.ResourceTypeVolume))
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "creating EBS Volume from datafy snapshot (%s): %s", snapshotId, err)
 		}
@@ -275,6 +270,54 @@ func resourceEBSVolumeCreate(ctx context.Context, d *schema.ResourceData, meta a
 		}())
 		d.Set(names.AttrSize, restoredVolume.VolumeSizeGB)
 		d.Set(names.AttrSnapshotID, snapshotId)
+		d.Set(names.AttrThroughput, volume.Throughput)
+		d.Set(names.AttrType, volume.VolumeType)
+
+		setTagsOut(ctx, datafy.RemoveDatafyTags(volume.Tags))
+
+		return diags
+	}
+
+	if d.Get("autoscaling_native").(bool) {
+		dc := meta.(*conns.AWSClient).DatafyClient(ctx)
+		datafied, err := dc.CreateDatafiedVolume(aws.ToString(input.AvailabilityZone), int64(aws.ToInt32(input.Size)),
+			input.Iops, input.Throughput, input.Encrypted, aws.ToString(input.KmsKeyId),
+			datafy.TagsFrom(input.TagSpecifications, awstypes.ResourceTypeVolume))
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "creating datafied EBS Volume: %s", err)
+		}
+		d.SetId(aws.ToString(datafied.VolumeId))
+
+		dvo, err := conn.DescribeVolumes(ctx, datafy.DescribeDatafiedVolumesInput(d.Id()))
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "can't find datafy volumes of EBS volume (%s): %s", d.Id(), err)
+		} else if len(dvo.Volumes) == 0 {
+			return sdkdiag.AppendErrorf(diags, "can't find datafy volumes of EBS volume (%s)", d.Id())
+		}
+
+		for _, volume := range dvo.Volumes {
+			datafyVolumeId := aws.ToString(volume.VolumeId)
+			if _, err := waitVolumeCreated(ctx, conn, datafyVolumeId, d.Timeout(schema.TimeoutCreate)); err != nil {
+				return sdkdiag.AppendErrorf(diags, "waiting for datafy volume (%s) of EBS Volume (%s) create: %s", datafyVolumeId, d.Id(), err)
+			}
+		}
+
+		volume := dvo.Volumes[0]
+		arnVal := arn.ARN{
+			Partition: meta.(*conns.AWSClient).Partition(ctx),
+			Service:   names.EC2,
+			Region:    meta.(*conns.AWSClient).Region(ctx),
+			AccountID: meta.(*conns.AWSClient).AccountID(ctx),
+			Resource:  fmt.Sprintf("volume/%s", d.Id()),
+		}
+		d.Set(names.AttrARN, arnVal.String())
+		d.Set(names.AttrAvailabilityZone, volume.AvailabilityZone)
+		d.Set(names.AttrEncrypted, volume.Encrypted)
+		d.Set(names.AttrIOPS, volume.Iops)
+		d.Set(names.AttrKMSKeyID, volume.KmsKeyId)
+		d.Set("multi_attach_enabled", volume.MultiAttachEnabled)
+		d.Set("outpost_arn", volume.OutpostArn)
+		d.Set(names.AttrSize, aws.ToInt32(input.Size))
 		d.Set(names.AttrThroughput, volume.Throughput)
 		d.Set(names.AttrType, volume.VolumeType)
 

--- a/internal/service/ec2/ebs_volume_datafy_test.go
+++ b/internal/service/ec2/ebs_volume_datafy_test.go
@@ -548,6 +548,48 @@ resource "aws_ebs_volume" "test" {
 `, rName))
 }
 
+func TestAccDatafyEC2EBSVolume_createNative(t *testing.T) {
+	ctx := acctest.Context(t)
+	var dv []awstypes.Volume
+	resourceName := "aws_ebs_volume.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccDatafyCheckVolumeDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatafyEBSVolumeConfig_native(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDatafyCheckVolumeExists(ctx, resourceName, &dv),
+					testAccDatafyCheckTagExists(ctx, &dv, "Name", rName),
+				),
+			},
+			{
+				RefreshState: true,
+			},
+		},
+	})
+}
+
+func testAccDatafyEBSVolumeConfig_native(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAvailableAZsNoOptIn(),
+		fmt.Sprintf(`
+resource "aws_ebs_volume" "test" {
+  availability_zone  = data.aws_availability_zones.available.names[0]
+  size               = 100
+  autoscaling_native = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName))
+}
+
 func testAccDatafyEBSVolumeConfig_snapshotInGroup(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),


### PR DESCRIPTION
## Summary

- Adds `CreateDatafiedVolume` to the `Client` interface, `ClientImpl`, and `MockClient`
- Adds `TagsFrom` helper to `internal/datafy/tags.go` (SDK v2 types)
- Wires `autoscaling_native = true` into the EBS volume create flow, routing to `POST api/v1/aws/volumes/create-autoscaling-volume`
- Adds `TestAccDatafyEC2EBSVolume_createNative` acceptance test

Port of the same change from `release/6.x` (#41).

## Test plan

- [ ] `AWS_PROFILE=development DATAFY_TOKEN=<dev-token> DATAFY_URL=https://iac-dev.datafy.io TF_ACC=1 go test ./internal/service/ec2/... -run TestAccDatafyEC2EBSVolume_createNative`
- [ ] `go test ./internal/service/ec2/... -run TestAccDatafyEC2EBSVolume_createNative` passes with mock client