### PR TITLE
DT-9731: [DT-10524] port autoscaling_native create path to release/4.x

### DIFF
--- a/internal/datafy/client.go
+++ b/internal/datafy/client.go
@@ -15,6 +15,7 @@ const DefaultUrl = "https://iac.datafy.io"
 type Client interface {
 	GetVolume(volumeId string) (*Volume, error)
 	CreateVolumeFromSnapshot(datafySnapshotId string, availabilityZone string, iops int32, throughput int32, tagz map[string]string) (*RestoredVolume, error)
+	CreateDatafiedVolume(availabilityZone string, diskSize int64, iops *int32, throughput *int32, encrypted *bool, kmsKeyId string, tagz map[string]string) (*Volume, error)
 	AttachVolume(instanceId string, volumeId string, deviceName string) error
 	DetachVolume(instanceId string, volumeId string) error
 	ModifyVolume(volumeId string, sizeGb *int32, iops *int32, throughput *int32) error
@@ -40,6 +41,20 @@ type createFromSnapshotsVolumeProperties struct {
 type createFromSnapshotsRequest struct {
 	Source           createFromSnapshotsSource           `json:"source"`
 	VolumeProperties createFromSnapshotsVolumeProperties `json:"volumeProperties"`
+}
+
+type createDatafiedVolumeProperties struct {
+	AvailabilityZone string `json:"availabilityZone"`
+	DiskSize         int64  `json:"diskSize"`
+	VolumeIops       *int32 `json:"volumeIops,omitempty"`
+	VolumeThroughput *int32 `json:"volumeThroughput,omitempty"`
+	Encrypted        *bool  `json:"encrypted,omitempty"`
+	KmsKeyId         string `json:"kmsKeyId,omitempty"`
+	Tags             []tags `json:"tags,omitempty"`
+}
+
+type createDatafiedVolumeRequest struct {
+	VolumeProperties createDatafiedVolumeProperties `json:"volumeProperties"`
 }
 
 type attachVolumeRequest struct {
@@ -153,6 +168,40 @@ func (c *ClientImpl) CreateVolumeFromSnapshot(datafySnapshotId string, availabil
 
 	if resp.StatusCode == http.StatusOK {
 		var out RestoredVolume
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			return nil, err
+		}
+		return &out, nil
+	}
+
+	return nil, toError(resp)
+}
+
+func (c *ClientImpl) CreateDatafiedVolume(availabilityZone string, diskSize int64, iops *int32, throughput *int32, encrypted *bool, kmsKeyId string, tagz map[string]string) (*Volume, error) {
+	tagsList := make([]tags, 0, len(tagz))
+	for k, v := range tagz {
+		tagsList = append(tagsList, tags{Key: k, Value: v})
+	}
+	request := createDatafiedVolumeRequest{
+		VolumeProperties: createDatafiedVolumeProperties{
+			AvailabilityZone: availabilityZone,
+			DiskSize:         diskSize,
+			VolumeIops:       iops,
+			VolumeThroughput: throughput,
+			Encrypted:        encrypted,
+			KmsKeyId:         kmsKeyId,
+			Tags:             tagsList,
+		},
+	}
+
+	resp, err := c.sendRequest(http.MethodPost, "api/v1/aws/volumes/create-autoscaling-volume", request)
+	if err != nil {
+		return nil, err
+	}
+	defer drain(resp)
+
+	if resp.StatusCode == http.StatusOK {
+		var out Volume
 		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 			return nil, err
 		}

--- a/internal/datafy/mock_client.go
+++ b/internal/datafy/mock_client.go
@@ -180,6 +180,58 @@ func (m *MockClient) DetachVolume(instanceId string, volumeId string) error {
 	}, time.Minute)
 }
 
+func (m *MockClient) CreateDatafiedVolume(availabilityZone string, diskSize int64, iops *int32, throughput *int32, _ *bool, _ string, tagz map[string]string) (*Volume, error) {
+	probe, err := m.ec2Client.CreateVolume(context.Background(), &ec2_sdkv2.CreateVolumeInput{
+		AvailabilityZone: aws.String(availabilityZone),
+		Size:             aws.Int32(1),
+		VolumeType:       types.VolumeTypeGp2,
+	})
+	if err != nil {
+		return nil, err
+	}
+	sourceVolumeId := aws.ToString(probe.VolumeId)
+	if _, err := m.ec2Client.DeleteVolume(context.Background(), &ec2_sdkv2.DeleteVolumeInput{VolumeId: &sourceVolumeId}); err != nil {
+		return nil, err
+	}
+
+	tags := []types.Tag{
+		{Key: aws.String(managedByTagKey), Value: aws.String(managedByTagValue)},
+		{Key: aws.String(sourceVolumeTagKey), Value: aws.String(sourceVolumeId)},
+		{Key: aws.String("datafy:volume-source"), Value: aws.String("native")},
+	}
+	for key, value := range tagz {
+		tags = append(tags, types.Tag{Key: aws.String(key), Value: aws.String(value)})
+	}
+
+	for i := 0; i < 2; i++ {
+		if _, err := m.ec2Client.CreateVolume(context.Background(), &ec2_sdkv2.CreateVolumeInput{
+			AvailabilityZone: aws.String(availabilityZone),
+			Size:             aws.Int32(int32(diskSize)),
+			VolumeType:       types.VolumeTypeGp3,
+			Iops:             iops,
+			Throughput:       throughput,
+			TagSpecifications: []types.TagSpecification{
+				{ResourceType: types.ResourceTypeVolume, Tags: tags},
+			},
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	source := &Volume{
+		Volume: &types.Volume{
+			VolumeId:         aws.String(sourceVolumeId),
+			AvailabilityZone: aws.String(availabilityZone),
+			Size:             aws.Int32(int32(diskSize)),
+			Iops:             iops,
+			Throughput:       throughput,
+		},
+		IsManaged: true, IsDatafied: true, HasSource: false,
+	}
+	m.SetVolume(sourceVolumeId, source)
+	return source, nil
+}
+
 func (m *MockClient) ModifyVolume(volumeId string, sizeGb *int32, iops *int32, throughput *int32) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/datafy/tags.go
+++ b/internal/datafy/tags.go
@@ -34,6 +34,20 @@ func DescribeDatafiedVolumesInput(sourceVolumeId string) *ec2.DescribeVolumesInp
 	}
 }
 
+// TagsFrom flattens TagSpecifications for the given resource type into a key/value map.
+func TagsFrom(ts []*ec2.TagSpecification, rt string) map[string]string {
+	tags := make(map[string]string)
+	for _, spec := range ts {
+		if aws.StringValue(spec.ResourceType) != rt {
+			continue
+		}
+		for _, t := range spec.Tags {
+			tags[aws.StringValue(t.Key)] = aws.StringValue(t.Value)
+		}
+	}
+	return tags
+}
+
 func RemoveDatafyTags(tags []*ec2.Tag) []*ec2.Tag {
 	return slices.Filter(tags, func(t *ec2.Tag) bool {
 		key := aws.StringValue(t.Key)

--- a/internal/service/ec2/ebs_volume.go
+++ b/internal/service/ec2/ebs_volume.go
@@ -81,6 +81,13 @@ func ResourceEBSVolume() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"autoscaling_native": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				ForceNew:    true,
+				Description: "Create the volume as a Datafy native autoscaling volume instead of a standard EBS volume.",
+			},
 			"availability_zone": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -267,6 +274,64 @@ func resourceEBSVolumeCreate(ctx context.Context, d *schema.ResourceData, meta i
 		}())
 		d.Set("size", restoredVolume.VolumeSizeGB)
 		d.Set("snapshot_id", snapshotId)
+		d.Set("throughput", volume.Throughput)
+		d.Set("type", volume.VolumeType)
+
+		SetTagsOut(ctx, datafy.RemoveDatafyTags(volume.Tags))
+
+		return diags
+	}
+
+	if d.Get("autoscaling_native").(bool) {
+		dc := meta.(*conns.AWSClient).DatafyClient()
+		var iops *int32
+		if input.Iops != nil {
+			v := int32(aws.Int64Value(input.Iops))
+			iops = &v
+		}
+		var throughput *int32
+		if input.Throughput != nil {
+			v := int32(aws.Int64Value(input.Throughput))
+			throughput = &v
+		}
+		datafied, err := dc.CreateDatafiedVolume(aws.StringValue(input.AvailabilityZone), aws.Int64Value(input.Size),
+			iops, throughput, input.Encrypted, aws.StringValue(input.KmsKeyId),
+			datafy.TagsFrom(input.TagSpecifications, ec2.ResourceTypeVolume))
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "creating datafied EBS Volume: %s", err)
+		}
+		d.SetId(aws.StringValue(datafied.VolumeId))
+
+		dvo, err := conn.DescribeVolumes(datafy.DescribeDatafiedVolumesInput(d.Id()))
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "can't find datafy volumes of EBS volume (%s): %s", d.Id(), err)
+		} else if len(dvo.Volumes) == 0 {
+			return sdkdiag.AppendErrorf(diags, "can't find datafy volumes of EBS volume (%s)", d.Id())
+		}
+
+		for _, volume := range dvo.Volumes {
+			datafyVolumeId := aws.StringValue(volume.VolumeId)
+			if _, err := WaitVolumeCreated(ctx, conn, datafyVolumeId, d.Timeout(schema.TimeoutCreate)); err != nil {
+				return sdkdiag.AppendErrorf(diags, "waiting for datafy volume (%s) of EBS Volume (%s) create: %s", datafyVolumeId, d.Id(), err)
+			}
+		}
+
+		volume := dvo.Volumes[0]
+		arnVal := arn.ARN{
+			Partition: meta.(*conns.AWSClient).Partition,
+			Service:   names.EC2,
+			Region:    meta.(*conns.AWSClient).Region,
+			AccountID: meta.(*conns.AWSClient).AccountID,
+			Resource:  fmt.Sprintf("volume/%s", d.Id()),
+		}
+		d.Set("arn", arnVal.String())
+		d.Set("availability_zone", volume.AvailabilityZone)
+		d.Set("encrypted", volume.Encrypted)
+		d.Set("iops", volume.Iops)
+		d.Set("kms_key_id", volume.KmsKeyId)
+		d.Set("multi_attach_enabled", volume.MultiAttachEnabled)
+		d.Set("outpost_arn", volume.OutpostArn)
+		d.Set("size", aws.Int64Value(input.Size))
 		d.Set("throughput", volume.Throughput)
 		d.Set("type", volume.VolumeType)
 

--- a/internal/service/ec2/ebs_volume_datafy_test.go
+++ b/internal/service/ec2/ebs_volume_datafy_test.go
@@ -561,6 +561,48 @@ resource "aws_ebs_volume" "test" {
 `, rName))
 }
 
+func TestAccDatafyEC2EBSVolume_createNative(t *testing.T) {
+	ctx := acctest.Context(t)
+	var dv []*ec2.Volume
+	resourceName := "aws_ebs_volume.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, ec2.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccDatafyCheckVolumeDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatafyEBSVolumeConfig_native(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDatafyCheckVolumeExists(ctx, resourceName, &dv),
+					testAccDatafyCheckTagExists(ctx, &dv, "Name", rName),
+				),
+			},
+			{
+				RefreshState: true,
+			},
+		},
+	})
+}
+
+func testAccDatafyEBSVolumeConfig_native(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAvailableAZsNoOptIn(),
+		fmt.Sprintf(`
+resource "aws_ebs_volume" "test" {
+  availability_zone  = data.aws_availability_zones.available.names[0]
+  size               = 1
+  autoscaling_native = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName))
+}
+
 func testAccDatafyEBSVolumeConfig_snapshotInGroup(rName string) string {
 	return acctest.ConfigCompose(
 		acctest.ConfigAvailableAZsNoOptIn(),


### PR DESCRIPTION
## Summary

- Adds `CreateDatafiedVolume` to the `Client` interface, `ClientImpl`, and `MockClient`
- Adds `TagsFrom` helper to `internal/datafy/tags.go` (SDK v1 types)
- Wires `autoscaling_native = true` into the EBS volume create flow, routing to `POST api/v1/aws/volumes/create-autoscaling-volume`
- Adds `TestAccDatafyEC2EBSVolume_createNative` acceptance test

Port of the same change from `release/6.x` (#41), adapted for SDK v1 (`aws-sdk-go`) and Go 1.19 (`for i := 0; i < 2; i++` instead of `for range 2`).

## Test plan

- [ ] `AWS_PROFILE=development DATAFY_TOKEN=<dev-token> DATAFY_URL=https://iac-dev.datafy.io TF_ACC=1 go test ./internal/service/ec2/... -run TestAccDatafyEC2EBSVolume_createNative`
- [ ] `go test ./internal/service/ec2/... -run TestAccDatafyEC2EBSVolume_createNative` passes with mock client